### PR TITLE
Api provides an endpoint for article creation

### DIFF
--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -10,15 +10,27 @@ class Api::ArticlesController < ApplicationController
 
   def show
     article = Article.find(params['id'])
-
     render json: { article: article }
   rescue ActiveRecord::RecordNotFound => e
     render_error('Article not found', 404)
+  end
+
+  def create
+    article = Article.create(article_params)
+    if article.persisted?
+      render json: { article: article }, status: 201
+    else
+      render_error(article.errors.full_messages.to_sentence, 422)
+    end
   end
 
   private
 
   def render_error(message, status)
     render json: { message: message }, status: status
+  end
+
+  def article_params
+    params[:article].permit(:title, :body, :category)
   end
 end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -19,7 +19,7 @@ class Api::ArticlesController < ApplicationController
   def create
     article = Article.create(article_params)
     if article.persisted?
-      render json: { article: article }, status: 201
+      render json: { article: article, message: 'Article created successfully' }, status: 201
     else
       render_error(article.errors.full_messages.to_sentence, 422)
     end

--- a/app/controllers/api/articles_controller.rb
+++ b/app/controllers/api/articles_controller.rb
@@ -1,10 +1,11 @@
 class Api::ArticlesController < ApplicationController
+  before_action :validate_params_presence, only: [:create]
   def index
-    if params['category'].nil?
-      latest_articles = Article.by_recently_created.limit(20)
-    else
-      latest_articles = Article.where(category: params['category']).by_recently_created.limit(20)
-    end
+    latest_articles = if params['category'].nil?
+                        Article.by_recently_created.limit(20)
+                      else
+                        Article.where(category: params['category']).by_recently_created.limit(20)
+                      end
     render json: { articles: latest_articles }
   end
 
@@ -32,5 +33,17 @@ class Api::ArticlesController < ApplicationController
 
   def article_params
     params[:article].permit(:title, :body, :category)
+  end
+
+  def validate_params_presence
+    if params[:article].nil?
+      render_error('Missing params', :unprocessable_entity)
+    elsif params[:article][:title].nil?
+      render_error("Title can't be blank", :unprocessable_entity)
+    elsif params[:article][:body].nil?
+      render_error("Body can't be blank", :unprocessable_entity)
+    elsif params[:article][:category].nil?
+      render_error("Category can't be blank", :unprocessable_entity)
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   namespace :api do
-    resources :articles, only: %i[index show]
+    resources :articles, only: %i[index show create]
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    body { "MyText" }
-    category { "MyString" }
+    title { "This is a wonderful header" }
+    body { "This is my article body" }
+    category { "economy" }
   end
 end

--- a/spec/requests/api/articles/create_spec.rb
+++ b/spec/requests/api/articles/create_spec.rb
@@ -26,19 +26,60 @@ RSpec.describe 'POST /api/articles', type: :request do
 
   describe 'unsuccessfully' do
     describe 'due to missing params' do
-      # write test in case we receive a POST request with missing params
+      before do
+        post '/api/articles', params: {}
+      end
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'is expected to respond with an error message' do
+        expect(response_json['message']).to eq 'Missing params'
+      end
     end
 
     describe 'due to missing title' do
-      # write test in case we receive a POST request with missing title
+      before do
+        post '/api/articles', params: {
+          body: 'There is water on Mars',
+          category: 'news'
+        }
+      end
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'is expected to respond with an error message' do
+        expect(response_json['message']).to eq "Title can't be blank"
+      end
     end
 
     describe 'due to missing body' do
-      # write test in case we receive a POST request with missing body
+      before do
+        post '/api/articles', params: {
+          title: 'Mars and Venus together',
+          category: 'news'
+        }
+      end
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'is expected to respond with an error message' do
+        expect(response_json['message']).to eq "Body can't be blank"
+      end
     end
 
     describe 'due to missing category' do
-      # write test in case we receive a POST request with missing category
+      before do
+        post '/api/articles', params: {
+          title: 'Mars and Venus together',
+          body: 'There is water on Mars'
+        }
+      end
+
+      it { is_expected.to have_http_status :unprocessable_entity }
+
+      it 'is expected to respond with an error message' do
+        expect(response_json['message']).to eq "Category can't be blank"
+      end
     end
   end
 end

--- a/spec/requests/api/articles/create_spec.rb
+++ b/spec/requests/api/articles/create_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe 'POST /api/articles', type: :request do
+  subject { response }
+
+  describe 'with valid params' do
+    before do
+      post '/api/articles', params: {
+        article: {
+          title: 'Mars and Venus together',
+          body: 'There is water on Mars',
+          category: 'news'
+        }
+      }
+      @article = Article.last
+    end
+
+    it { is_expected.to have_http_status :created }
+
+    it 'is expected to create an instance of Article' do
+      expect(@article).to_not eq nil
+    end
+  end
+end

--- a/spec/requests/api/articles/create_spec.rb
+++ b/spec/requests/api/articles/create_spec.rb
@@ -18,5 +18,27 @@ RSpec.describe 'POST /api/articles', type: :request do
     it 'is expected to create an instance of Article' do
       expect(@article).to_not eq nil
     end
+
+    it 'is expected to have saved the article in the database' do
+      expect(@article.title).to eq 'Mars and Venus together'
+    end
+  end
+
+  describe 'unsuccessfully' do
+    describe 'due to missing params' do
+      # write test in case we receive a POST request with missing params
+    end
+
+    describe 'due to missing title' do
+      # write test in case we receive a POST request with missing title
+    end
+
+    describe 'due to missing body' do
+      # write test in case we receive a POST request with missing body
+    end
+
+    describe 'due to missing category' do
+      # write test in case we receive a POST request with missing category
+    end
   end
 end

--- a/spec/requests/api/articles/create_spec.rb
+++ b/spec/requests/api/articles/create_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe 'POST /api/articles', type: :request do
     it 'is expected to have saved the article in the database' do
       expect(@article.title).to eq 'Mars and Venus together'
     end
+
+    it 'is expected to respond with a confirmation message' do
+      expect(response_json['message']).to eq "Article created successfully"
+    end
   end
 
   describe 'unsuccessfully' do
@@ -40,8 +44,10 @@ RSpec.describe 'POST /api/articles', type: :request do
     describe 'due to missing title' do
       before do
         post '/api/articles', params: {
-          body: 'There is water on Mars',
-          category: 'news'
+          article: {
+            body: 'There is water on Mars',
+            category: 'news'
+          }
         }
       end
 
@@ -55,8 +61,10 @@ RSpec.describe 'POST /api/articles', type: :request do
     describe 'due to missing body' do
       before do
         post '/api/articles', params: {
-          title: 'Mars and Venus together',
-          category: 'news'
+          article: {
+            title: 'Mars and Venus together',
+            category: 'news'
+          }
         }
       end
 
@@ -70,8 +78,10 @@ RSpec.describe 'POST /api/articles', type: :request do
     describe 'due to missing category' do
       before do
         post '/api/articles', params: {
-          title: 'Mars and Venus together',
-          body: 'There is water on Mars'
+          article: {
+            title: 'Mars and Venus together',
+            body: 'There is water on Mars'
+          }
         }
       end
 


### PR DESCRIPTION
### This PR contains:
- adds request spec for article create route
- adds create route to /api/articles
- adds create method in articles_controller.rb
- adds sad path tests in article create request spec

[pivotal tracker Feature](https://www.pivotaltracker.com/story/show/180855039)

@DefyCab @Mljungho @elvitak 